### PR TITLE
Replace codecov with python-coverage-comment-action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+# .github/workflows/coverage.yml
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Run tests & display coverage
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+      # Gives the action the necessary permissions for looking up the
+      # workflow that launched this workflow, and download the related
+      # artifact that contains the comment to be published
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,12 +35,55 @@ jobs:
       - name: Coverage reporting
         run: |
           coverage combine
-          coverage report -m
-          coverage xml
-          coverage html
-      - name: Publish coverage results
-        uses: codecov/codecov-action@v4
+          coverage report --show-missing
+        env:
+          COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
+      - name: Store coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: .coverage.${{ matrix.python-version }}
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: tests
+    permissions:
+      # If the author is a maintainer, the permission level is set by the
+      # values below.
+      # `pull-requests: write` is needed for publishing new comments in pull
+      # requests.
+      # `contents: write` is needed for pushing data to the
+      # `python-coverage-comment-action` branch, and for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      # In case the pull request comes from a forked repository, the maximum
+      # permission level is read, so the permissions below won't be acted upon
+      # by GitHub.
+      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        id: download
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Coverage comment
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_COVERAGE_FILES: true
+
+      - name: Store Pull Request comment to be posted
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt
 
   isort:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,0 @@
-coverage:
-  status:
-    project: false
-    patch: false
-    changes: false


### PR DESCRIPTION
Using this fork to try the integration of Python Coverage Comment Action